### PR TITLE
Update renderText.js

### DIFF
--- a/src/render/renderText.js
+++ b/src/render/renderText.js
@@ -17,7 +17,8 @@ export default function renderText(a) {
     fill: normalizeColor(a.color || '#000'),
     fontSize: a.size
   });
-  text.innerHTML = a.content;
+  var textNode = document.createTextNode(a.content);
+	text.appendChild(textNode);
 
   return text;
 }


### PR DESCRIPTION
Creating a text node for it works in IE as well. Just using innerHTML works on firefox but not on IE (results in empty text nodes)